### PR TITLE
Fix CustomModelData implementation

### DIFF
--- a/spigot-common/v1_14_R1/src/main/java/dev/kejona/crossplatforms/spigot/v1_14_R1/Adapter_v1_14_R1.java
+++ b/spigot-common/v1_14_R1/src/main/java/dev/kejona/crossplatforms/spigot/v1_14_R1/Adapter_v1_14_R1.java
@@ -4,6 +4,7 @@ import dev.kejona.crossplatforms.spigot.adapter.NbtAccessor;
 import dev.kejona.crossplatforms.spigot.utils.InventoryUtils;
 import dev.kejona.crossplatforms.spigot.v1_13_R2.Adapter_v1_13_R2;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.Plugin;
 
 import javax.annotation.Nonnull;
@@ -22,7 +23,9 @@ public class Adapter_v1_14_R1 extends Adapter_v1_13_R2 {
 
     @Override
     public void setCustomModelData(@Nonnull ItemStack stack, @Nullable Integer value) {
-        InventoryUtils.requireItemMeta(stack).setCustomModelData(value);
+        ItemMeta meta = InventoryUtils.requireItemMeta(stack);
+        meta.setCustomModelData(value);
+        stack.setItemMeta(meta);
     }
 
     @Override


### PR DESCRIPTION
ItemMeta needs to be set after meta#setCustomModelData is called, otherwise ItemMeta wouldn't be refreshed including the custom-model-data